### PR TITLE
Changed date labels to hidden, added text selectable to total

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -407,8 +407,10 @@ void TransactionView::showDetails()
 
 void TransactionView::enableDateRangeWidget(bool enable)
 {
-    dateFrom->setEnabled(enable);
-    dateTo->setEnabled(enable);
+    dateFrom->setVisible(enable);
+    dateTo->setVisible(enable);
+    to->setVisible(enable);
+    range->setVisible(enable);
 }
 
 QWidget *TransactionView::createDateRangeWidget()
@@ -420,7 +422,8 @@ QWidget *TransactionView::createDateRangeWidget()
     QHBoxLayout *layout = new QHBoxLayout(dateRangeWidget);
     layout->setContentsMargins(0,0,0,0);
     layout->addSpacing(23);
-    layout->addWidget(new QLabel(tr("Range:")));
+    range = new QLabel(tr("Range:"));
+    layout->addWidget(range);
 
     dateFrom = new QDateTimeEdit(this);
     dateFrom->setDisplayFormat("dd/MM/yy");
@@ -428,7 +431,8 @@ QWidget *TransactionView::createDateRangeWidget()
     dateFrom->setMinimumWidth(100);
     dateFrom->setDate(QDate::currentDate().addDays(-7));
     layout->addWidget(dateFrom);
-    layout->addWidget(new QLabel(tr("to")));
+    to = new QLabel(tr("to"));
+    layout->addWidget(to);
 
     dateTo = new QDateTimeEdit(this);
     dateTo->setDisplayFormat("dd/MM/yy");
@@ -441,7 +445,8 @@ QWidget *TransactionView::createDateRangeWidget()
     layout->addWidget(new QLabel(tr("Total:")));
     totalAmountWidget = new QLabel(this);
     totalAmountWidget->setText("0");
-    totalAmountWidget->setFixedWidth(100);
+    totalAmountWidget->setFixedWidth(120);
+    totalAmountWidget->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard);
     layout->addWidget(totalAmountWidget);
 
     // Hide by default

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -57,6 +57,8 @@ private:
     QFrame *dateRangeWidget;
     QDateTimeEdit *dateFrom;
     QDateTimeEdit *dateTo;
+    QLabel *to;
+    QLabel *range;
 
     QWidget *createDateRangeWidget();
 


### PR DESCRIPTION
A user interface design style change to only show date labels when the range is selected from the pull down.  (To reduce user confusion from unused date fields when other ranges are selected) Added mouse and keyboard text selection to transaction total label so that this value can be copied.