### PR TITLE
Cache block hash, move block version bits, more misc fixes.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -172,6 +172,7 @@ std::string HelpMessage()
     strUsage += "  -bantime=<n>           " + _("Number of seconds to keep misbehaving peers from reconnecting (default: 86400)") + "\n";
     strUsage += "  -maxreceivebuffer=<n>  " + _("Maximum per-connection receive buffer, <n>*1000 bytes (default: 5000)") + "\n";
     strUsage += "  -maxsendbuffer=<n>     " + _("Maximum per-connection send buffer, <n>*1000 bytes (default: 1000)") + "\n";
+    strUsage += "  -stakeaddress=<address>" + _("Restrict the wallet to only stake inputs from one address") + "\n";
 	strUsage += "  -strictprotocol=<n>     " + _("Only connect to peers using the same protocol version. Warning this will cause low peer count.") + "\n";
 #ifdef USE_UPNP
 #if USE_UPNP

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -360,6 +360,8 @@ bool CheckStakeKernelHash(unsigned int nBits, const CBlock& blockFrom, unsigned 
 	unsigned int i;
 	for(i = 0; i < (nHashDrift); i++) //iterate the hashing
 	{
+        fWalletStaking = true;
+
         //hash this iteration
 		nTryTime = nTimeTx + nHashDrift - i;
 		hashProofOfStake = stakeHash(nTryTime, nTxPrevTime, ss, prevout.n, nTxPrevOffset, nTimeBlockFrom); 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4068,6 +4068,9 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake)
     if (!pblock.get())
         return NULL;
 
+    // Only use the first 4 bits for the version encoding
+    pblock->nVersion = pblock->nVersion << 28;
+
     // Create coinbase tx
     CTransaction txNew;
     txNew.vin.resize(1);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,6 +73,7 @@ map<std::string, std::pair<int, int> > mapGetBlocksRequests;
 std::map <std::string, int> mapPeerRejectedBlocks;
 bool fStrictProtocol = false;
 bool fStrictIncoming = false;
+bool fWalletStaking = false;
 
 // Constant stuff for coinbase transactions we create:
 CScript COINBASE_FLAGS;
@@ -4481,7 +4482,9 @@ void BitcoinMiner(CWallet *pwallet, bool fProofOfStake)
     {
         if (fShutdown)
             return;
-        
+
+        fWalletStaking = false;
+
         while (vNodes.empty() || IsInitialBlockDownload() || pwallet->IsLocked()  ||  !fMintableCoins)
         {
             nLastCoinStakeSearchInterval = 0;
@@ -4494,6 +4497,7 @@ void BitcoinMiner(CWallet *pwallet, bool fProofOfStake)
 
         if(mapHashedBlocks.count(nBestHeight)) //search our map of hashed blocks, see if bestblock has been hashed yet
         {
+            fWalletStaking = true;
             if(GetTime() - mapHashedBlocks[nBestHeight] < max(pwallet->nHashInterval, (unsigned int)1)) // wait a 'hash interval' until trying to hash again
             {
 				Sleep(1000); // 2.5 second sleep for this thread

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -913,7 +913,18 @@ bool CBlock::ReadFromDisk(const CBlockIndex* pindex, bool fReadTransactions)
         return false;
     if (GetHash() != pindex->GetBlockHash())
         return error("CBlock::ReadFromDisk() : GetHash() doesn't match index");
+
+    this->hashBlock = pindex->GetBlockHash();
+
     return true;
+}
+
+uint256 CBlock::GetHash() const
+{
+    if (hashBlock != 0)
+        return hashBlock;
+
+    return Hash9(BEGIN(nVersion), END(nNonce));
 }
 
 
@@ -2237,6 +2248,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock, std::string& strErr)
 {
     // Check for duplicate
     uint256 hash = pblock->GetHash();
+    pblock->SetHash(hash);
     if (mapBlockIndex.count(hash))
         return error("ProcessBlock() : already have block %d %s", mapBlockIndex[hash]->nHeight, hash.ToString().substr(0,20).c_str());
     if (mapOrphanBlocks.count(hash))

--- a/src/main.h
+++ b/src/main.h
@@ -98,6 +98,7 @@ extern std::map <std::string, int> mapPeerRejectedBlocks;
 extern bool fStrictProtocol;
 extern bool fStrictIncoming;
 extern bool fGenerateBitcoins;
+extern bool fWalletStaking;
 
 // Settings
 extern int64 nTransactionFee;

--- a/src/main.h
+++ b/src/main.h
@@ -848,6 +848,7 @@ public:
 
     // memory only
     mutable std::vector<uint256> vMerkleTree;
+    uint256 hashBlock;
 
     // Denial-of-service detection:
     mutable int nDoS;
@@ -900,10 +901,9 @@ public:
         return (nBits == 0);
     }
 
-    uint256 GetHash() const
-    {
-        return Hash9(BEGIN(nVersion), END(nNonce));
-    }
+    uint256 GetHash() const;
+
+    void SetHash(uint256 hash){ this->hashBlock = hash; }
 
     int64 GetBlockTime() const
     {

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -95,12 +95,7 @@ Value getinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("keypoololdest", (boost::int64_t)pwalletMain->GetOldestKeyPoolTime()));
     obj.push_back(Pair("keypoolsize",   pwalletMain->GetKeyPoolSize()));
     obj.push_back(Pair("paytxfee",      ValueFromAmount(nTransactionFee)));
-	bool nStaking = false;
-	if(mapHashedBlocks.count(nBestHeight))
-		nStaking = true;
-	else if(mapHashedBlocks.count(nBestHeight - 1) && nLastCoinStakeSearchInterval)
-		nStaking = true;	
-	obj.push_back(Pair("staking status", (nStaking ? "Staking Active" : "Staking Not Active")));
+	obj.push_back(Pair("staking status", (fWalletStaking ? "Staking Active" : "Staking Not Active")));
 	
 	std::string strLockState = "";
 	if(pwalletMain->IsLocked())

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1303,10 +1303,26 @@ bool CWallet::SelectStakeCoins(std::set<std::pair<const CWalletTx*,unsigned int>
 	vector<COutput> vCoins;
     AvailableCoins(vCoins, true);
 	int64 nAmountSelected = 0;
+
+    bool fStakeFromAddress = false;
+    CBitcoinAddress addressStake;
+    CScript scriptStakeFrom;
+    if (mapArgs.count("-stakeaddress")) {
+        addressStake = CBitcoinAddress(mapArgs.at("-stakeaddress"));
+        fStakeFromAddress = addressStake.IsValid();
+    }
 	
 	BOOST_FOREACH(const COutput& out, vCoins)
 	{
-		if(nAmountSelected + out.tx->vout[out.i].nValue < nTargetAmount)
+		if (fStakeFromAddress) {
+            CTxDestination dest;
+            if (!ExtractDestination(out.tx->vout[out.i].scriptPubKey, dest))
+                continue;
+            if (CBitcoinAddress(dest).ToString() != addressStake.ToString())
+                continue;
+        }
+
+        if (nAmountSelected + out.tx->vout[out.i].nValue < nTargetAmount)
 		{
 			if(GetTime() - out.tx->GetTxTime() > (fTestNet ? nStakeMinAge : nStakeMinAgeV2))
 			{

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1590,13 +1590,14 @@ uint64 CWallet::GetTimeToNextMaturity()
     BOOST_FOREACH(PAIRTYPE(const CWalletTx*, unsigned int) pcoin, setCoins)
     {
         uint64 nCurrentAge = GetTime() - pcoin.first->nTime;
-        if(nCurrentAge > nStakeAge)
+        if (nCurrentAge > nStakeAge)
             return 0;
 
-        int64 nTimeToMaturity = nStakeAge - nCurrentAge;
+        uint64 nTimeToMaturity = nStakeAge - nCurrentAge;
 
-        if(nCurrentAge < nTimeToNextMaturity)
-            nTimeToNextMaturity = nCurrentAge;
+        // see if this coin matures in less time than the 'current' oldest coin
+        if(nTimeToMaturity < nTimeToNextMaturity)
+            nTimeToNextMaturity = nTimeToMaturity;
     }
 
     return nTimeToNextMaturity;
@@ -1623,8 +1624,7 @@ bool CWallet::GetStakeWeight(const CKeyStore& keystore, uint64& nMinWeight, uint
 
     if (setCoins.empty())
         return false;
-	
-	uint64 nPrevAge = 0; // for nHoursToMaturity calculation
+
 	uint64 nStakeAge = nStakeMinAgeV2;
 
     if(fTestNet)


### PR DESCRIPTION
- Add `stakeaddress=` arg which allows user to set one address they would like to stake from, causing any utxo's from other addresses to not stake.
- Move the block.nVersion bits to the first 4 bits of the int. This will allow for use of the rest of the bits within the block version to be used for signalling.
- Use a more accurate method to track whether the wallet's status is *staking*.
- Fix the *time to maturity* calculations.
- Cache a block's hash when it is first calculated. X11 is a heavy algorithm, and having multiple `GetHash()` calls on a block really slows down performance.