### PR TITLE
[Depends] Compile dependencies with qt gif enabled.

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -36,7 +36,6 @@ $(package)_config_opts += -no-eglfs
 $(package)_config_opts += -no-feature-style-windowsmobile
 $(package)_config_opts += -no-feature-style-windowsce
 $(package)_config_opts += -no-freetype
-$(package)_config_opts += -no-gif
 $(package)_config_opts += -no-glib
 $(package)_config_opts += -no-gstreamer
 $(package)_config_opts += -no-icu


### PR DESCRIPTION
When building statically using the *depends* system, the in wallet gifs were not working because QT was built without gifs.